### PR TITLE
Replace babel-preset-es2015-rollup with regular babel settings

### DIFF
--- a/config/rollup.js
+++ b/config/rollup.js
@@ -29,7 +29,14 @@ module.exports = (file) => {
       babel({
         babelrc: false,
         exclude: 'node_modules/**',
-        presets: [require.resolve('babel-preset-es2015-rollup')],
+        plugins: [
+          require.resolve('babel-plugin-external-helpers'),
+        ],
+        presets: [
+          [require.resolve('babel-preset-es2015'), {
+            modules: false,
+          }],
+        ],
       }),
     ],
   };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "ps-tree": "^1.1.0"
   },
   "dependencies": {
-    "babel-preset-es2015-rollup": "^1.2.0",
+    "babel-plugin-external-helpers": "^6.8.0",
+    "babel-preset-es2015": "^6.16.0",
     "browser-sync": "^2.16.0",
     "cssnano": "^3.7.4",
     "es6-promisify": "^5.0.0",


### PR DESCRIPTION
This replaces the babel-preset-es2015-rollup dependency with straight Babel config and plugin/preset references.

This closes #13 