### PR TITLE
WIP - Add handlebars template to allow nested pages to access root level assets

### DIFF
--- a/template/app/pages/index.hbs
+++ b/template/app/pages/index.hbs
@@ -2,4 +2,4 @@
 title: A Catchy Title
 ---
 <h1>Hello there!!</h1>
-<a href="/deep/">Deep</a>
+<a href="{{nestedUrl 'deep/index.html'}}">Deep</a>

--- a/template/app/views/layouts/application.hbs
+++ b/template/app/views/layouts/application.hbs
@@ -1,13 +1,13 @@
 <html>
 <head>
   <title>{{title}}</title>
-  <link crossorigin="anonymous" href="/app.css" media="all" rel="stylesheet" />
-  <link crossorigin="anonymous" href="/styles.css" media="all" rel="stylesheet" />
+  <link crossorigin="anonymous" href="{{nestedUrl 'app.css'}}" media="all" rel="stylesheet" />
+  <link crossorigin="anonymous" href="{{nestedUrl 'styles.css'}}" media="all" rel="stylesheet" />
 </head>
 <body>
   {{{contents}}}
 
   {{> footer}}
-  <script src="/app.umd.js"></script>
+  <script src="{{nestedUrl 'app.umd.js'}}"></script>
 </body>
 </html>

--- a/template/app/views/layouts/secondary.hbs
+++ b/template/app/views/layouts/secondary.hbs
@@ -1,13 +1,13 @@
 <html>
 <head>
   <title>Secondary - {{title}}</title>
-  <link crossorigin="anonymous" href="/app.css" media="all" rel="stylesheet" />
-  <link crossorigin="anonymous" href="/styles.css" media="all" rel="stylesheet" />
+  <link crossorigin="anonymous" href="{{nestedUrl 'app.css'}}" media="all" rel="stylesheet" />
+  <link crossorigin="anonymous" href="{{nestedUrl 'styles.css'}}" media="all" rel="stylesheet" />
 </head>
 <body>
   {{{contents}}}
 
   {{> footer}}
-  <script src="/app.umd.js"></script>
+  <script src="{{nestedUrl 'app.umd.js'}}"></script>
 </body>
 </html>

--- a/template/slipcast.js
+++ b/template/slipcast.js
@@ -1,3 +1,15 @@
 module.exports = {
   files: ['app.css', 'app.js', 'styles.scss'],
+  handlebars: function(handlebars) {
+    handlebars.registerHelper('nestedUrl', function(url, options) {
+      var path = options.data.root.path.dir,
+          prepend = '';
+
+      if (path) {
+        prepend = path.split('/').map(() => '../').join('');
+      }
+
+      return new handlebars.SafeString(prepend + url);
+    })
+  }
 };


### PR DESCRIPTION
Addresses issue [#24](https://github.com/CoffeeAndCode/slipcast/issues/24)

### Things done:
- Added a handlebars default helper to the template that allows nested pages to access root level assets. Previously, trying to link to a root level asset from a nested page required you to specify the relative URL yourself.
- Provided example usage of the helper in the template files. 

### How to use:
- When referencing anything from an `href` or `src` property in markup, wrap in with the `nestedUrl` helper like this: 
```
<a href="{{nestedUrl 'index.html'}}">Home</a>
<img alt="" src="{{nestedUrl 'images/image.png'}}">
```